### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A local [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that connects Claude to your Steam library. Ask natural-language questions about your games without ever touching the API yourself.
 
+[![steam-mcp MCP server](https://glama.ai/mcp/servers/jkiley129/steam-mcp/badges/card.svg)](https://glama.ai/mcp/servers/jkiley129/steam-mcp)
+
 ```
 "What have I been playing lately?"
 "Suggest something from my backlog I haven't touched yet."


### PR DESCRIPTION
This PR adds a badge for the [steam-mcp](https://glama.ai/mcp/servers/jkiley129/steam-mcp) server listing in Glama MCP server directory.

[![steam-mcp MCP server](https://glama.ai/mcp/servers/jkiley129/steam-mcp/badges/card.svg)](https://glama.ai/mcp/servers/jkiley129/steam-mcp)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.